### PR TITLE
Update Actions to Node.js 24 native versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,14 +13,11 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -33,7 +30,7 @@ jobs:
           sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
       - id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
@@ -49,4 +46,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
checkout v4 -> v6, configure-pages v5 -> v6, deploy-pages v4 -> v5. Remove FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 flag (no longer needed). upload-pages-artifact stays at v3 (composite action, not node-based).