### PR TITLE
Update upload-pages-artifact to v5 (Node.js 24 native)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       - run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
 


### PR DESCRIPTION
v5.0.0 bundles upload-artifact v7 which targets node24, eliminating the last Node.js 20 deprecation warning.