### PR TITLE
Fix mixed-content image by using baseURL from hugo.toml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
       - id: pages
         uses: actions/configure-pages@v6
 
-      - run: hugo --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - run: hugo --minify
 
       - uses: actions/upload-pages-artifact@v5
         with:


### PR DESCRIPTION
Removing --baseURL from the build command so Hugo uses the https:// baseURL configured in hugo.toml instead of the http:// URL returned by configure-pages, which was causing browser-blocked mixed-content errors on the avatar image srcset.